### PR TITLE
James Kariuki Interview Test: AddItem Endpoint And Fix Project Bugs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.h2database:h2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,3 +14,5 @@ services:
       - mysql_data:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
 
+volumes:
+  mysql_data:

--- a/src/main/java/com/carepay/interviewtest2025/dto/ClaimCreateRequest.java
+++ b/src/main/java/com/carepay/interviewtest2025/dto/ClaimCreateRequest.java
@@ -3,6 +3,7 @@ package com.carepay.interviewtest2025.dto;
 import com.carepay.interviewtest2025.model.ClaimStatus;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,8 +17,10 @@ public class ClaimCreateRequest {
     private String policyNumber;
 
     @NotBlank
-    private String patientName;
-    private final ClaimStatus status = ClaimStatus.OPEN;
+    private String claimantName;
+
+    @NotNull
+    private ClaimStatus status;
 
 
     @Valid

--- a/src/main/java/com/carepay/interviewtest2025/dto/ClaimCreateRequest.java
+++ b/src/main/java/com/carepay/interviewtest2025/dto/ClaimCreateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
@@ -12,6 +13,7 @@ import java.util.List;
 
 @NoArgsConstructor
 @Getter
+@Setter
 public class ClaimCreateRequest {
     @NotBlank
     private String policyNumber;

--- a/src/main/java/com/carepay/interviewtest2025/dto/ClaimItemCreateRequest.java
+++ b/src/main/java/com/carepay/interviewtest2025/dto/ClaimItemCreateRequest.java
@@ -20,5 +20,6 @@ public class ClaimItemCreateRequest {
     private BigDecimal amount;
 
 
-    private final ClaimItemStatus status = ClaimItemStatus.PENDING;
+    @NotNull
+    private ClaimItemStatus status;
 }

--- a/src/main/java/com/carepay/interviewtest2025/dto/ClaimItemCreateRequest.java
+++ b/src/main/java/com/carepay/interviewtest2025/dto/ClaimItemCreateRequest.java
@@ -8,9 +8,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import lombok.Setter;
 
 @NoArgsConstructor
 @Getter
+@Setter
 public class ClaimItemCreateRequest {
     @NotBlank
     private String description;

--- a/src/main/java/com/carepay/interviewtest2025/dto/ClaimItemResponse.java
+++ b/src/main/java/com/carepay/interviewtest2025/dto/ClaimItemResponse.java
@@ -5,10 +5,8 @@ import lombok.Value;
 
 import java.math.BigDecimal;
 
-@Value
-public class ClaimItemResponse {
-    private Long id;
-    private String description;
-    private BigDecimal amount;
-    private ClaimItemStatus status;
-}
+public record ClaimItemResponse(
+    Long id,
+    String description,
+    BigDecimal amount,
+    ClaimItemStatus status) { }

--- a/src/main/java/com/carepay/interviewtest2025/dto/ClaimResponse.java
+++ b/src/main/java/com/carepay/interviewtest2025/dto/ClaimResponse.java
@@ -6,12 +6,10 @@ import lombok.Value;
 import java.time.Instant;
 import java.util.List;
 
-@Value
-public class ClaimResponse {
-    Long id;
-    String policyNumber;
-    String claimantName;
-    ClaimStatus status;
-    Instant createdAt;
-    List<ClaimItemResponse> items;
-}
+public record ClaimResponse(
+    Long id,
+    String policyNumber,
+    String claimantName,
+    ClaimStatus status,
+    Instant createdAt,
+    List<ClaimItemResponse> items) { }

--- a/src/main/java/com/carepay/interviewtest2025/model/Claim.java
+++ b/src/main/java/com/carepay/interviewtest2025/model/Claim.java
@@ -38,8 +38,8 @@ public class Claim {
     private String policyNumber;
 
 
-    @Column(name = "patient_name", nullable = false)
-    private String patientName;
+    @Column(name = "claimant_name", nullable = false)
+    private String claimantName;
 
 
     @Enumerated(EnumType.STRING)
@@ -62,6 +62,6 @@ public class Claim {
 
     public void addItem(ClaimItem item) {
         item.setClaim(this);
-        //this.items.add(item);
+        this.items.add(item);
     }
 }

--- a/src/main/java/com/carepay/interviewtest2025/service/ClaimService.java
+++ b/src/main/java/com/carepay/interviewtest2025/service/ClaimService.java
@@ -30,7 +30,7 @@ public ClaimService(ClaimRepository claimRepository, ClaimItemRepository itemRep
     public ClaimResponse createClaim (ClaimCreateRequest req){
         Claim claim = new Claim();
         claim.setPolicyNumber(req.getPolicyNumber());
-        claim.setPatientName(req.getPatientName());
+        claim.setClaimantName(req.getClaimantName());
         claim.setStatus(req.getStatus());
 
 
@@ -63,7 +63,7 @@ public ClaimService(ClaimRepository claimRepository, ClaimItemRepository itemRep
         return new ClaimResponse(
                 claim.getId(),
                 claim.getPolicyNumber(),
-                claim.getPatientName(),
+                claim.getClaimantName(),
                 claim.getStatus(),
                 claim.getCreatedAt(),
                 items

--- a/src/main/java/com/carepay/interviewtest2025/service/ClaimService.java
+++ b/src/main/java/com/carepay/interviewtest2025/service/ClaimService.java
@@ -49,6 +49,23 @@ public ClaimService(ClaimRepository claimRepository, ClaimItemRepository itemRep
         return toResponse(saved);
     }
 
+
+    @Transactional
+    public ClaimItemResponse addItem(Long claimId, ClaimItemCreateRequest req) {
+        Claim claim = claimRepository.findById(claimId)
+            .orElseThrow(() -> new IllegalArgumentException("Claim not found: " + claimId));
+
+        ClaimItem item = new ClaimItem();
+        item.setDescription(req.getDescription());
+        item.setAmount(req.getAmount());
+        item.setStatus(req.getStatus());
+        claim.addItem(item);
+
+        ClaimItem savedItem = itemRepository.save(item);
+        return new ClaimItemResponse(savedItem.getId(), savedItem.getDescription(), savedItem.getAmount(), savedItem.getStatus());
+    }
+
+
     public ClaimResponse getClaim (Long id){
         Claim claim = claimRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Claim not found: " + id));

--- a/src/main/java/com/carepay/interviewtest2025/web/ClaimController.java
+++ b/src/main/java/com/carepay/interviewtest2025/web/ClaimController.java
@@ -34,7 +34,7 @@ public class ClaimController {
     @PostMapping("/{id}/items")
     @ResponseStatus(HttpStatus.CREATED)
     public ClaimItemResponse addItem(@PathVariable Long id, @Valid @RequestBody ClaimItemCreateRequest request) {
-        throw new NotImplementedException();
+        return claimService.addItem(id, request);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/carepay/interviewtest2025/web/GlobalExceptionHandler.java
+++ b/src/main/java/com/carepay/interviewtest2025/web/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.carepay.interviewtest2025.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, String> handleNotFound(IllegalArgumentException ex) {
+        return Map.of("error", ex.getMessage());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 5000
+  port: 8080
 
 spring:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,5 +16,5 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
   liquibase:
-    enabled: false
+    enabled: true
     change-log: classpath:db/changelog/changelog-master.xml

--- a/src/main/resources/db/changelog/001-db-tables.xml
+++ b/src/main/resources/db/changelog/001-db-tables.xml
@@ -5,5 +5,47 @@
                    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <changeSet id="001-db-tables" author="admin">
+        <createTable tableName="claim">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="policy_number" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="claimant_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP"/>
+        </createTable>
+
+        <createTable tableName="claim_items">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="claim_id" type="BIGINT">
+                <constraints nullable="false"
+                  foreignKeyName="fk_claim_item_claim"
+                  references="claim(id)"/>
+            </column>
+            <column name="description" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="amount" type="DECIMAL(10,2)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP"/>
+        </createTable>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/002-sample-data.xml
+++ b/src/main/resources/db/changelog/002-sample-data.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="002-sample-data" author="admin">
+
+    <insert tableName="claim">
+      <column name="id" value="18"/>
+      <column name="policy_number" value="POL-1850"/>
+      <column name="claimant_name" value="James Kariuki"/>
+      <column name="status" value="OPEN"/>
+      <column name="created_at" valueDate="2026-01-01T00:00:00"/>
+    </insert>
+
+    <insert tableName="claim_items">
+      <column name="id" value="21"/>
+      <column name="claim_id" value="18"/>
+      <column name="description" value="Screen replacement"/>
+      <column name="amount" value="120.50"/>
+      <column name="status" value="PENDING"/>
+      <column name="created_at" valueDate="2026-01-01T00:00:00"/>
+    </insert>
+
+    <insert tableName="claim_items">
+      <column name="id" value="22"/>
+      <column name="claim_id" value="18"/>
+      <column name="description" value="Battery"/>
+      <column name="amount" value="40.00"/>
+      <column name="status" value="APPROVED"/>
+      <column name="created_at" valueDate="2026-01-01T00:00:00"/>
+    </insert>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/002-sample-data.xml
+++ b/src/main/resources/db/changelog/002-sample-data.xml
@@ -7,7 +7,7 @@
   <changeSet id="002-sample-data" author="admin">
 
     <insert tableName="claim">
-      <column name="id" value="18"/>
+      <column name="id" value="1"/>
       <column name="policy_number" value="POL-1850"/>
       <column name="claimant_name" value="James Kariuki"/>
       <column name="status" value="OPEN"/>
@@ -15,8 +15,8 @@
     </insert>
 
     <insert tableName="claim_items">
-      <column name="id" value="21"/>
-      <column name="claim_id" value="18"/>
+      <column name="id" value="1"/>
+      <column name="claim_id" value="1"/>
       <column name="description" value="Screen replacement"/>
       <column name="amount" value="120.50"/>
       <column name="status" value="PENDING"/>
@@ -24,8 +24,8 @@
     </insert>
 
     <insert tableName="claim_items">
-      <column name="id" value="22"/>
-      <column name="claim_id" value="18"/>
+      <column name="id" value="2"/>
+      <column name="claim_id" value="1"/>
       <column name="description" value="Battery"/>
       <column name="amount" value="40.00"/>
       <column name="status" value="APPROVED"/>

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -5,4 +5,5 @@
                    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <include file="001-db-tables.xml" relativeToChangelogFile="true"/>
+    <include file="002-sample-data.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/test/java/com/carepay/interviewtest2025/service/ClaimServiceTest.java
+++ b/src/test/java/com/carepay/interviewtest2025/service/ClaimServiceTest.java
@@ -1,0 +1,156 @@
+package com.carepay.interviewtest2025.service;
+
+import com.carepay.interviewtest2025.dto.ClaimCreateRequest;
+import com.carepay.interviewtest2025.dto.ClaimItemCreateRequest;
+import com.carepay.interviewtest2025.dto.ClaimItemResponse;
+import com.carepay.interviewtest2025.dto.ClaimResponse;
+import com.carepay.interviewtest2025.model.Claim;
+import com.carepay.interviewtest2025.model.ClaimItem;
+import com.carepay.interviewtest2025.model.ClaimItemStatus;
+import com.carepay.interviewtest2025.model.ClaimStatus;
+import com.carepay.interviewtest2025.repository.ClaimItemRepository;
+import com.carepay.interviewtest2025.repository.ClaimRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClaimServiceTest {
+
+    @Mock
+    private ClaimRepository claimRepository;
+
+    @Mock
+    private ClaimItemRepository itemRepository;
+
+    @InjectMocks
+    private ClaimService claimService;
+
+    private Claim claim;
+
+    @BeforeEach
+    void setUp() {
+        claim = new Claim();
+        claim.setId(1L);
+        claim.setPolicyNumber("POL-123");
+        claim.setClaimantName("Jane Doe");
+        claim.setStatus(ClaimStatus.OPEN);
+    }
+
+    @Test
+    void createClaim_shouldCreateClaimWithNoItems() {
+        ClaimCreateRequest request = new ClaimCreateRequest();
+        request.setPolicyNumber("POL-123");
+        request.setClaimantName("Jane Doe");
+        request.setStatus(ClaimStatus.OPEN);
+
+        when(claimRepository.save(any(Claim.class))).thenReturn(claim);
+
+        ClaimResponse response = claimService.createClaim(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.policyNumber()).isEqualTo("POL-123");
+        assertThat(response.claimantName()).isEqualTo("Jane Doe");
+        assertThat(response.status()).isEqualTo(ClaimStatus.OPEN);
+        verify(claimRepository).save(any(Claim.class));
+    }
+
+    @Test
+    void createClaim_shouldCreateClaimWithItems() {
+        ClaimItemCreateRequest itemRequest = new ClaimItemCreateRequest();
+        itemRequest.setDescription("Screen replacement");
+        itemRequest.setAmount(new BigDecimal("120.50"));
+        itemRequest.setStatus(ClaimItemStatus.PENDING);
+
+        ClaimCreateRequest request = new ClaimCreateRequest();
+        request.setPolicyNumber("POL-123");
+        request.setClaimantName("Jane Doe");
+        request.setStatus(ClaimStatus.OPEN);
+        request.setItems(List.of(itemRequest));
+
+        ClaimItem claimItem = new ClaimItem();
+        claimItem.setId(1L);
+        claimItem.setDescription("Screen replacement");
+        claimItem.setAmount(new BigDecimal("120.50"));
+        claimItem.setStatus(ClaimItemStatus.PENDING);
+        claim.getItems().add(claimItem);
+
+        when(claimRepository.save(any(Claim.class))).thenReturn(claim);
+
+        ClaimResponse response = claimService.createClaim(request);
+
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().get(0).description()).isEqualTo("Screen replacement");
+    }
+
+    @Test
+    void getClaim_shouldReturnClaim_whenExists() {
+        when(claimRepository.findById(1L)).thenReturn(Optional.of(claim));
+
+        ClaimResponse response = claimService.getClaim(1L);
+
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.policyNumber()).isEqualTo("POL-123");
+    }
+
+    @Test
+    void getClaim_shouldThrowException_whenNotFound() {
+        when(claimRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> claimService.getClaim(99L))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Claim not found: 99");
+    }
+
+    @Test
+    void addItem_shouldAddItemToClaim() {
+        ClaimItemCreateRequest request = new ClaimItemCreateRequest();
+        request.setDescription("Battery");
+        request.setAmount(new BigDecimal("40.00"));
+        request.setStatus(ClaimItemStatus.PENDING);
+
+        ClaimItem savedItem = new ClaimItem();
+        savedItem.setId(1L);
+        savedItem.setDescription("Battery");
+        savedItem.setAmount(new BigDecimal("40.00"));
+        savedItem.setStatus(ClaimItemStatus.PENDING);
+
+        when(claimRepository.findById(1L)).thenReturn(Optional.of(claim));
+        when(itemRepository.save(any(ClaimItem.class))).thenReturn(savedItem);
+
+        ClaimItemResponse response = claimService.addItem(1L, request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.description()).isEqualTo("Battery");
+        assertThat(response.amount()).isEqualByComparingTo("40.00");
+    }
+
+    @Test
+    void addItem_shouldThrowException_whenClaimNotFound() {
+        ClaimItemCreateRequest request = new ClaimItemCreateRequest();
+        request.setDescription("Battery");
+        request.setAmount(new BigDecimal("40.00"));
+        request.setStatus(ClaimItemStatus.PENDING);
+
+        when(claimRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> claimService.addItem(99L, request))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Claim not found: 99");
+    }
+}

--- a/src/test/java/com/carepay/interviewtest2025/web/ClaimControllerIntegrationTest.java
+++ b/src/test/java/com/carepay/interviewtest2025/web/ClaimControllerIntegrationTest.java
@@ -1,0 +1,141 @@
+package com.carepay.interviewtest2025.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.carepay.interviewtest2025.model.Claim;
+import com.carepay.interviewtest2025.model.ClaimStatus;
+import com.carepay.interviewtest2025.repository.ClaimRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ClaimControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ClaimRepository claimRepository;
+
+    private Long savedClaimId;
+
+    @BeforeEach
+    void setUp() {
+        claimRepository.deleteAll();
+
+        Claim claim = new Claim();
+        claim.setPolicyNumber("POL-123");
+        claim.setClaimantName("Jane Doe");
+        claim.setStatus(ClaimStatus.OPEN);
+        savedClaimId = claimRepository.save(claim).getId();
+    }
+
+    @Test
+    void createClaim_shouldReturn201_withValidRequest() throws Exception {
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+            "policyNumber", "POL-456",
+            "claimantName", "John Smith",
+            "status", "OPEN",
+            "items", java.util.List.of()
+        ));
+
+        mockMvc.perform(post("/api/claims")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.policyNumber").value("POL-456"))
+            .andExpect(jsonPath("$.claimantName").value("John Smith"))
+            .andExpect(jsonPath("$.status").value("OPEN"));
+    }
+
+    @Test
+    void createClaim_shouldReturn400_whenPolicyNumberMissing() throws Exception {
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+            "claimantName", "John Smith",
+            "status", "OPEN"
+        ));
+
+        mockMvc.perform(post("/api/claims")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getClaim_shouldReturn200_whenClaimExists() throws Exception {
+        mockMvc.perform(get("/api/claims/{id}", savedClaimId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(savedClaimId))
+            .andExpect(jsonPath("$.policyNumber").value("POL-123"))
+            .andExpect(jsonPath("$.claimantName").value("Jane Doe"));
+    }
+
+    @Test
+    void getClaim_shouldReturn404_whenClaimNotFound() throws Exception {
+        mockMvc.perform(get("/api/claims/{id}", 999L))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("Claim not found: 999"));
+    }
+
+    @Test
+    void addItem_shouldReturn201_withValidRequest() throws Exception {
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+            "description", "Back cover",
+            "amount", "25.00",
+            "status", "PENDING"
+        ));
+
+        mockMvc.perform(post("/api/claims/{id}/items", savedClaimId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.description").value("Back cover"))
+            .andExpect(jsonPath("$.amount").value(25.00))
+            .andExpect(jsonPath("$.status").value("PENDING"));
+    }
+
+    @Test
+    void addItem_shouldReturn400_whenDescriptionMissing() throws Exception {
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+            "amount", "25.00",
+            "status", "PENDING"
+        ));
+
+        mockMvc.perform(post("/api/claims/{id}/items", savedClaimId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void addItem_shouldReturn404_whenClaimNotFound() throws Exception {
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+            "description", "Back cover",
+            "amount", "25.00",
+            "status", "PENDING"
+        ));
+
+        mockMvc.perform(post("/api/claims/{id}/items", 999L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("Claim not found: 999"));
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: none
+    database-platform: org.hibernate.dialect.H2Dialect
+  liquibase:
+    enabled: true
+    change-log: classpath:db/changelog/changelog-master.xml
+  docker:
+    compose:
+      enabled: false


### PR DESCRIPTION
This PR completes the implementation of the addItem endpoint, fixes several bugs found in the existing codebase, and adds database migrations via Liquibase along with unit and integration tests.

### Changes Made
Infrastructure
- Fixed compose.yaml missing top-level volumes declaration
- Fixed application.yml: liquibase.enabled was set to false
- Fixed application.yml: server.port changed from 5000 to 8080

Database
- Completed 001-db-tables.xml changeset with claim and claim_items tables
- Added 002-sample-data.xml changeset with sample claim and items

Bug Fixes
- Fixed Claim entity: patient_name column renamed to claimant_name
- Fixed Claim.addItem(): this.items.add(item) was commented out
- Fixed ClaimCreateRequest: patientName renamed to claimantName
- Fixed ClaimCreateRequest: status was hardcoded final, now accepts client input
- Fixed ClaimItemCreateRequest: status was hardcoded final, now accepts client input
- Fixed ClaimCreateRequest: missing @Setter causing Jackson deserialization failure
- Fixed ClaimService.createClaim(): was calling getPatientName() instead of getClaimantName()
- Added GlobalExceptionHandler: returns 404 instead of 500 for missing resources

Implementation
- Implemented addItem() in ClaimController delegating to ClaimService
- Implemented addItem() in ClaimService with proper item persistence

Improvements
- Converted ClaimResponse and ClaimItemResponse from @Value classes to Java records
- Added @Setter to request DTOs to enable proper Jackson deserialization

### Notes / Considerations
- Idempotency was not implemented for POST /api/claims but could be 
  added using a unique constraint on policy_number.
- IllegalArgumentException is used for not found cases — in a production 
  application a custom ClaimNotFoundException would be more appropriate.
- No authentication/authorization has been implemented.